### PR TITLE
Add the alternate interface vendor.qti.qcril.am

### DIFF
--- a/debian/audiosystem-passthrough.install
+++ b/debian/audiosystem-passthrough.install
@@ -1,2 +1,2 @@
-debian/tmp/usr/libexec/audiosystem-passthrough/audiosystem-passthrough usr/lib/audiosystem-passthrough/audiosystem-passthrough
+debian/tmp/usr/lib/audiosystem-passthrough/audiosystem-passthrough usr/lib/audiosystem-passthrough
 audiosystem-passthrough.conf usr/share/upstart/sessions

--- a/src/impl-qti.c
+++ b/src/impl-qti.c
@@ -41,7 +41,10 @@
 #include "dbus-comms.h"
 
 #define BINDER_DEVICE               GBINDER_DEFAULT_HWBINDER
-#define QCRIL_IFACE_1_0(x)          "vendor.qti.hardware.radio.am@1.0::" x
+#define QCRIL_IFACE_HW_RADIO_1_0(x) "vendor.qti.hardware.radio.am@1.0::" x
+#define QCRIL_AUDIO_HW_RADIO_1_0             QCRIL_IFACE_HW_RADIO_1_0("IQcRilAudio")
+#define QCRIL_AUDIO_HW_RADIO_CALLBACK_1_0    QCRIL_IFACE_HW_RADIO_1_0("IQcRilAudioCallback")
+#define QCRIL_IFACE_1_0(x)          "vendor.qti.qcril.am@1.0::" x
 #define QCRIL_AUDIO_1_0             QCRIL_IFACE_1_0("IQcRilAudio")
 #define QCRIL_AUDIO_CALLBACK_1_0    QCRIL_IFACE_1_0("IQcRilAudioCallback")
 
@@ -66,6 +69,8 @@ typedef struct am_client {
     HidlApp *app;
     char* fqname;
     gchar* slot;
+    gchar* interfaceName;
+    gchar* interfaceCallbackName;
     GBinderServiceManager* sm;
     GBinderLocalObject* local;
     GBinderRemoteObject* remote;
@@ -170,7 +175,7 @@ am_client_callback(
     AmClient* am = user_data;
     const char* iface = gbinder_remote_request_interface(req);
 
-    if (!g_strcmp0(iface, QCRIL_AUDIO_CALLBACK_1_0)) {
+    if (!g_strcmp0(iface, am->interfaceCallbackName)) {
         GBinderReader reader;
         GBinderLocalReply* reply = gbinder_local_object_new_reply(obj);
         const char* str;
@@ -203,20 +208,30 @@ static gboolean
 am_client_connect(
         AmClient* am)
 {
+    am->interfaceName = QCRIL_AUDIO_1_0;
+    am->interfaceCallbackName = QCRIL_AUDIO_CALLBACK_1_0;
     int status = 0;
+    am->fqname = g_strconcat(am->interfaceName, "/", am->slot, NULL);
     am->remote = gbinder_servicemanager_get_service_sync(am->sm,
         am->fqname, &status); /* auto-released reference */
-
+    if (!am->remote) {
+        DBG("vendor.qti.qcril.am failed, trying vendor.qti.hardware.radio.am...");
+        am->interfaceName = QCRIL_AUDIO_HW_RADIO_1_0;
+        am->interfaceCallbackName = QCRIL_AUDIO_HW_RADIO_CALLBACK_1_0;
+        am->fqname = g_strconcat(am->interfaceName, "/", am->slot, NULL);
+        am->remote = gbinder_servicemanager_get_service_sync(am->sm,
+            am->fqname, &status); /* auto-released reference */
+    }
     if (am->remote) {
         GBinderLocalRequest* req;
 
         DBG("Connected to %s", am->fqname);
         gbinder_remote_object_ref(am->remote);
-        am->client = gbinder_client_new(am->remote, QCRIL_AUDIO_1_0);
+        am->client = gbinder_client_new(am->remote, am->interfaceName);
         am->death_id = gbinder_remote_object_add_death_handler(am->remote,
             am_remote_died, am);
         am->local = gbinder_servicemanager_new_local_object(am->sm,
-            QCRIL_AUDIO_CALLBACK_1_0, am_client_callback, am);
+            am->interfaceCallbackName, am_client_callback, am);
 
         /* oneway IQcRilAudio::setCallback(IQcRilAudioCallback) */
         req = gbinder_client_new_request(am->client);
@@ -227,6 +242,7 @@ am_client_connect(
         DBG("setCallback %s status %d", am->slot, status);
         return TRUE;
     }
+    DBG("no interfaces could be configured!");
     return FALSE;
 }
 
@@ -256,7 +272,6 @@ am_client_new(
 
     am->app = app;
     am->slot = g_strdup(slot);
-    am->fqname = g_strconcat(QCRIL_AUDIO_1_0, "/", slot, NULL);
     am->sm = gbinder_servicemanager_ref(app->sm);
     return am;
 }

--- a/src/impl-qti.c
+++ b/src/impl-qti.c
@@ -218,6 +218,7 @@ am_client_connect(
         DBG("vendor.qti.qcril.am failed, trying vendor.qti.hardware.radio.am...");
         am->interfaceName = QCRIL_AUDIO_HW_RADIO_1_0;
         am->interfaceCallbackName = QCRIL_AUDIO_HW_RADIO_CALLBACK_1_0;
+        g_free(am->fqname);
         am->fqname = g_strconcat(am->interfaceName, "/", am->slot, NULL);
         am->remote = gbinder_servicemanager_get_service_sync(am->sm,
             am->fqname, &status); /* auto-released reference */


### PR DESCRIPTION
Thats necessary because some devices use a vendor service called differently to do the job.